### PR TITLE
Refactor Oanda wrappers into dedicated classes

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from config.settings import settings
 from bot.handlers import setup_bot
-from oanda.client import get_client
+from oanda import OandaClient
 
 
 def main() -> None:
@@ -10,7 +10,7 @@ def main() -> None:
 
     # Initialize Oanda client (not used yet)
     if settings.oanda_token:
-        get_client(settings.oanda_token)
+        OandaClient(settings.oanda_token)
 
     application = setup_bot(settings.telegram_token)
     application.run_polling()

--- a/oanda/__init__.py
+++ b/oanda/__init__.py
@@ -1,0 +1,7 @@
+"""Expose public API for the Oanda helpers."""
+
+from .client import OandaClient
+from .orderbook import OrderBookService
+
+__all__ = ["OandaClient", "OrderBookService"]
+

--- a/oanda/client.py
+++ b/oanda/client.py
@@ -1,6 +1,20 @@
+"""Basic Oanda API client wrapper."""
+
 from oandapyV20 import API
 
 
-def get_client(token: str) -> API:
-    """Return an authenticated Oanda API client."""
-    return API(access_token=token)
+class OandaClient:
+    """Manage authentication and requests to the Oanda REST API."""
+
+    def __init__(self, token: str) -> None:
+        """Initialise the underlying API client with the provided token."""
+        self._api = API(access_token=token)
+
+    def request(self, endpoint) -> dict:
+        """Execute a prepared endpoint request and return the response."""
+        self._api.request(endpoint)
+        return endpoint.response
+
+
+__all__ = ["OandaClient"]
+

--- a/oanda/orderbook.py
+++ b/oanda/orderbook.py
@@ -1,10 +1,21 @@
+"""Orderbook related helpers for the Oanda API."""
+
 from oandapyV20.endpoints.orderbook import OrderBook
-from .client import get_client
+
+from .client import OandaClient
 
 
-def fetch_orderbook(oanda_token: str, instrument: str):
-    """Fetch the orderbook for a given instrument."""
-    client = get_client(oanda_token)
-    r = OrderBook(instrument=instrument)
-    client.request(r)
-    return r.response
+class OrderBookService:
+    """High level interface for fetching orderbook data."""
+
+    def __init__(self, client: OandaClient) -> None:
+        self._client = client
+
+    def fetch(self, instrument: str) -> dict:
+        """Retrieve the orderbook for the given instrument."""
+        request = OrderBook(instrument=instrument)
+        return self._client.request(request)
+
+
+__all__ = ["OrderBookService"]
+


### PR DESCRIPTION
## Summary
- Replace function-based Oanda helpers with class-based `OandaClient` and `OrderBookService`
- Expose new helpers via `oanda` package and update bot bootstrap to use them

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b4f327fef88328a1b22ff7e522fa19